### PR TITLE
Improve reaction overflow panel

### DIFF
--- a/components/mdx/compact-reactions.tsx
+++ b/components/mdx/compact-reactions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export type CompactReactionItem = {
+  type: string;
+  count: number;
+  label?: string;
+  icon: ReactNode;
+  tooltipIcon?: ReactNode;
+};
+
+type CompactReactionsProps = {
+  reactions: CompactReactionItem[];
+  maxVisible: number;
+  renderReaction: (reaction: CompactReactionItem) => ReactNode;
+  renderOverflowTrigger: (hiddenCount: number) => ReactElement;
+  renderPanelReaction?: (reaction: CompactReactionItem) => ReactNode;
+  showAllInPanel?: boolean;
+  panelClassName?: string;
+  panelSideOffset?: number;
+  panelSide?: ComponentPropsWithoutRef<typeof PopoverContent>["side"];
+  panelAlign?: ComponentPropsWithoutRef<typeof PopoverContent>["align"];
+};
+
+export function CompactReactions({
+  reactions,
+  maxVisible,
+  renderReaction,
+  renderOverflowTrigger,
+  renderPanelReaction,
+  showAllInPanel = true,
+  panelClassName,
+  panelSideOffset = 6,
+  panelSide = "bottom",
+  panelAlign = "center",
+}: CompactReactionsProps) {
+  const visibleReactions = reactions.slice(0, maxVisible);
+  const hiddenReactions = reactions.slice(maxVisible);
+  const panelReactions = showAllInPanel ? reactions : hiddenReactions;
+
+  return (
+    <>
+      {visibleReactions.map((reaction) => renderReaction(reaction))}
+
+      {hiddenReactions.length > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            {renderOverflowTrigger(hiddenReactions.length)}
+          </PopoverTrigger>
+          <PopoverContent
+            align={panelAlign}
+            className={panelClassName}
+            side={panelSide}
+            sideOffset={panelSideOffset}
+          >
+            <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+              {panelReactions.map((reaction) => (
+                <div key={reaction.type} className="min-w-0">
+                  {renderPanelReaction ? renderPanelReaction(reaction) : renderReaction(reaction)}
+                </div>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}

--- a/components/mdx/engagement-stats.tsx
+++ b/components/mdx/engagement-stats.tsx
@@ -4,6 +4,8 @@ import { memo } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Eye, Heart, ThumbsUp, Rocket } from "lucide-react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { CompactReactions, type CompactReactionItem } from "@/components/mdx/compact-reactions";
 import { cn } from "@/lib/utils";
 
 const REACTION_ICONS = {
@@ -11,6 +13,14 @@ const REACTION_ICONS = {
   like: ThumbsUp,
   rocket: Rocket,
 } as const;
+
+const REACTION_LABELS = {
+  heart: "Heart",
+  like: "Like",
+  rocket: "Rocket",
+} as const;
+
+const MAX_VISIBLE_REACTIONS = 3;
 
 export const EngagementStats = memo(function EngagementStats({ slug, className }: { slug: string; className?: string }) {
   const engagement = useQuery(api.engagement.getEngagement, { slug });
@@ -23,28 +33,70 @@ export const EngagementStats = memo(function EngagementStats({ slug, className }
   );
 
   const views = engagement.views;
-  const reactions = engagement.reactions.filter((r) => r.count > 0);
+  const reactions = engagement.reactions
+    .filter((r) => r.count > 0)
+    .sort((a, b) => b.count - a.count);
+  const reactionItems: CompactReactionItem[] = reactions.map((reaction) => {
+    const Icon = REACTION_ICONS[reaction.type as keyof typeof REACTION_ICONS];
+    const label = REACTION_LABELS[reaction.type as keyof typeof REACTION_LABELS];
+
+    return {
+      type: reaction.type,
+      count: reaction.count,
+      label,
+      icon: Icon ? (
+        <Icon className="h-3.5 w-3.5 fill-muted-foreground/20" />
+      ) : (
+        <span className="text-sm leading-none">{reaction.type}</span>
+      ),
+      tooltipIcon: Icon ? (
+        <Icon className="h-3.5 w-3.5 fill-primary-foreground/20" />
+      ) : (
+        <span className="text-sm leading-none">{reaction.type}</span>
+      ),
+    };
+  });
 
   return (
-    <div className={cn("flex items-center gap-4 text-xs font-medium text-muted-foreground", className)}>
-      <div className="flex items-center gap-1.5" title="Views">
-        <Eye className="h-3.5 w-3.5" />
-        <span>{views}</span>
+    <TooltipProvider>
+      <div className={cn("flex items-center gap-4 text-xs font-medium text-muted-foreground", className)}>
+        <div className="flex items-center gap-1.5" title="Views">
+          <Eye className="h-3.5 w-3.5" />
+          <span>{views}</span>
+        </div>
+
+        <CompactReactions
+          reactions={reactionItems}
+          maxVisible={MAX_VISIBLE_REACTIONS}
+          panelClassName="w-auto min-w-[10rem] rounded-xl border border-border/60 bg-background/95 p-2 text-foreground shadow-lg backdrop-blur"
+          panelSide="bottom"
+          panelSideOffset={8}
+          renderReaction={(reaction) => (
+            <div key={reaction.type} className="flex items-center gap-1.5" title={reaction.label ?? reaction.type}>
+              {reaction.icon}
+              <span>{reaction.count}</span>
+            </div>
+          )}
+          renderOverflowTrigger={(hiddenCount) => (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-sm text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              aria-label={`Show ${hiddenCount} more reactions`}
+            >
+              <span>+{hiddenCount}</span>
+            </button>
+          )}
+          renderPanelReaction={(reaction) => (
+            <div className="flex items-center justify-between gap-2 rounded-lg border border-border/50 bg-muted/50 px-2 py-1.5 text-xs text-foreground">
+              <div className="flex min-w-0 items-center gap-1.5">
+                {reaction.tooltipIcon ?? reaction.icon}
+                {reaction.label ? <span className="truncate">{reaction.label}</span> : null}
+              </div>
+              <span className="font-semibold">{reaction.count}</span>
+            </div>
+          )}
+        />
       </div>
-      
-      {reactions.map((r) => {
-        const Icon = REACTION_ICONS[r.type as keyof typeof REACTION_ICONS];
-        return (
-          <div key={r.type} className="flex items-center gap-1.5" title={r.type}>
-            {Icon ? (
-              <Icon className="h-3.5 w-3.5 fill-muted-foreground/20" />
-            ) : (
-              <span className="text-sm leading-none">{r.type}</span>
-            )}
-            <span>{r.count}</span>
-          </div>
-        );
-      })}
-    </div>
+    </TooltipProvider>
   );
 });

--- a/components/mdx/inline-engagement.tsx
+++ b/components/mdx/inline-engagement.tsx
@@ -21,6 +21,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CompactReactions, type CompactReactionItem } from "@/components/mdx/compact-reactions";
 
 const EmojiPicker = dynamic(() => import("emoji-picker-react"), {
   ssr: false,
@@ -31,6 +32,8 @@ const PREDEFINED_REACTIONS = [
   { type: "like", icon: ThumbsUp, label: "Like", emoji: "👍" },
   { type: "rocket", icon: Rocket, label: "Rocket", emoji: "🚀" },
 ];
+
+const MAX_VISIBLE_CUSTOM_REACTIONS = 3;
 
 export function InlineEngagement({ slug, className }: { slug: string; className?: string }) {
   const engagement = useQuery(api.engagement.getEngagement, { slug });
@@ -51,6 +54,17 @@ export function InlineEngagement({ slug, className }: { slug: string; className?
   const reactionsMap = new Map(
     engagement?.reactions.map((r) => [r.type, r.count]) ?? []
   );
+  const customReactions = (engagement?.reactions ?? [])
+    .filter((reaction) => reaction.count > 0)
+    .filter((reaction) => !PREDEFINED_REACTIONS.some((predefined) => predefined.type === reaction.type))
+    .sort((a, b) => b.count - a.count);
+  const customReactionItems: CompactReactionItem[] = customReactions.map((reaction) => ({
+    type: reaction.type,
+    count: reaction.count,
+    label: reaction.type,
+    icon: <span className="text-sm leading-none">{reaction.type}</span>,
+    tooltipIcon: <span className="text-sm leading-none">{reaction.type}</span>,
+  }));
 
   const emojiPickerTheme = resolvedTheme === "dark" ? Theme.DARK : Theme.LIGHT;
 
@@ -94,29 +108,61 @@ export function InlineEngagement({ slug, className }: { slug: string; className?
             );
           })}
 
-          {/* User's custom reactions */}
-          <AnimatePresence mode="popLayout">
-            {userReactions
-              .filter((type) => !PREDEFINED_REACTIONS.some((pr) => pr.type === type))
-              .map((type) => (
-                <motion.div
-                  key={type}
-                  initial={{ scale: 0, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0, opacity: 0 }}
-                >
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 px-2 gap-1.5 rounded-md text-primary bg-primary/5 hover:bg-primary/10"
-                    onClick={() => handleToggleReaction(type)}
+            <CompactReactions
+              reactions={customReactionItems}
+              maxVisible={MAX_VISIBLE_CUSTOM_REACTIONS}
+              panelClassName="w-auto min-w-[10rem] rounded-xl border border-border/60 bg-background/95 p-2 text-foreground shadow-lg backdrop-blur"
+              renderReaction={(reaction) => {
+                const isActive = userReactions.includes(reaction.type);
+
+              return (
+                <AnimatePresence key={reaction.type} mode="popLayout">
+                  <motion.div
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0, opacity: 0 }}
                   >
-                    <span className="text-sm leading-none">{type}</span>
-                    <span className="text-xs font-bold">{reactionsMap.get(type)}</span>
-                  </Button>
-                </motion.div>
-              ))}
-          </AnimatePresence>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={cn(
+                        "h-8 px-2 gap-1.5 rounded-md transition-all hover:bg-muted",
+                        isActive ? "text-primary bg-primary/5 hover:bg-primary/10" : "text-muted-foreground"
+                      )}
+                      onClick={() => handleToggleReaction(reaction.type)}
+                    >
+                      {reaction.icon}
+                      <span className="text-xs font-bold">{reaction.count}</span>
+                    </Button>
+                  </motion.div>
+                </AnimatePresence>
+              );
+            }}
+            renderOverflowTrigger={(hiddenCount) => (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 gap-1.5 rounded-md text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
+              >
+                <span className="text-xs font-bold">+{hiddenCount}</span>
+              </Button>
+            )}
+              renderPanelReaction={(reaction) => (
+                <button
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 rounded-lg border border-border/50 bg-muted/50 px-2 py-1.5 text-xs text-foreground transition-colors hover:bg-muted",
+                    userReactions.includes(reaction.type) && "border-primary/40 bg-primary/10 text-primary"
+                  )}
+                  onClick={() => handleToggleReaction(reaction.type)}
+                >
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    {reaction.tooltipIcon ?? reaction.icon}
+                  </div>
+                  <span className="font-semibold">{reaction.count}</span>
+                </button>
+              )}
+            />
 
           {/* Add Reaction Button */}
           <Popover>

--- a/content/en/blogs/260326-the-tax-of-software-that-wont-die.mdx
+++ b/content/en/blogs/260326-the-tax-of-software-that-wont-die.mdx
@@ -1,0 +1,131 @@
+export const metadata = {
+  title: "The Tax of Software That Won't Die",
+  publishDate: "2026-03-26",
+  description: "A ghost PufferPanel service, 91 GB of orphaned Docker volumes, and Apple's simulator runtimes all taught me the same thing: software keeps charging rent long after the product says it's gone.",
+  category: "Technology",
+  cover_image: "https://images.unsplash.com/photo-1516321318423-f06f85e504b3",
+  tldr: "I've seen both kinds of digital garbage: the leftovers that were my fault, and the leftovers the platform won't let me remove. The common thread is that modern software makes creation easy, then keeps charging tax when it's time for something to die.",
+  tags: ["infrastructure", "docker", "apple"],
+};
+
+*Photo by <a href="https://unsplash.com/@carlheyerdahl?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Carl Heyerdahl</a> on <a href="https://unsplash.com/photos/black-flat-screen-computer-monitor-KE0nC8-58MQ?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>*
+
+I spent part of last month paying two different kinds of software tax.
+
+The first one was my fault.
+
+I removed [PufferPanel](https://www.pufferpanel.com/ "mention | Game server management panel I had previously installed outside Dokploy") from [Dokploy](https://dokploy.com/ "mention | My self-hosted deployment layer, which only manages what it created") and moved on with my life. Or at least I thought I did. Weeks later I went digging into a VPS with suspiciously high RAM usage and found `pufferpanel.service` still alive at the host layer, quietly running a Minecraft server with an `-Xmx8192M` heap. One forgotten service. Eight gigabytes of budgeted memory. Just sitting there like rent I forgot I was paying.
+
+The second one was not my fault.
+
+On macOS, I ran into the mess around iOS simulator runtimes. The files were bad. The accounting was worse. My Storage settings were telling me Documents was eating **200+ GB**. I clicked in expecting a graveyard. The UI showed me five files totaling maybe **1.5 GB**. At that point the only honest question is: what exactly are you counting, Apple?
+
+That is the part that got under my skin.
+
+Deleting things is annoying. Fine. Being told I have hundreds of gigabytes in "Documents" while the visible list barely clears a rounding error is worse. [Xcode](https://developer.apple.com/xcode/ "reference | Apple's official IDE and the place where simulator runtimes are supposed to be managed") gives you a neat component-management story. `xcrun simctl` gives you cleanup commands. Then you start digging through forum threads like [this Apple discussion](https://developer.apple.com/forums/thread/812992 "reference | Report of orphaned simulator runtime assets that stay on disk in SIP-protected storage"), Stack Overflow folklore, and random cleanup guides until the category itself stops making sense. Maybe you are looking at stale devices. Maybe half-installed runtimes. Maybe mounted CoreSimulator images. Maybe runtime assets sitting under `/System/Library/AssetsV2`, with the real files parked behind system protection.
+
+That is when the process stops feeling like cleanup and starts feeling like exorcism. The happy path is simple: open Xcode settings, remove the runtime, maybe run `simctl` cleanup. The broken path is stupid: close Xcode, inspect CoreSimulator folders, figure out whether the runtime is a file or a mounted volume, fight permissions, restart simulator services, reboot, maybe reinstall, then check whether the disk space even came back. By the time you understand what happened, the cleanup itself is barely the problem anymore.
+
+Those two incidents are not the same story. One is a confession. The other is a complaint.
+
+But they land on the same conclusion.
+
+Modern software is very good at creating things. It is terrible at ending them. And in the AI era, that is not a philosophical bug anymore. It is a bill.
+
+## The Easy Part Is Creation
+
+Spinning up software has never been easier.
+
+One click in a control panel. One `docker compose up`. One dependency install. One simulator runtime download. One experiment you swear is temporary.
+
+The cost feels tiny in the moment because the system spreads it out for you. Storage used to feel cheap. RAM used to feel abstract. Now both feel like delayed invoices, especially when half the industry is busy turning idle hardware into AI throughput. Background services disappear behind dashboards. Containers make everything feel disposable until you realize the disposable part was only the interface.
+
+What actually gets created underneath is not disposable at all. It is state. Volumes. caches. services. assets. directories with names you never typed and locations you never visit.
+
+This is where my PufferPanel mistake becomes more interesting than "haha I forgot to uninstall a thing."
+
+I did remove it from the product layer. I removed it from the place where I normally *see* my services. That was enough to let my brain mark it as finished. But the host did not care about my perception. [systemd](https://systemd.io/ "reference | Linux service manager that keeps host-level units alive until you explicitly stop and disable them") was still doing exactly what I had asked it to do weeks earlier: keep that service alive.
+
+The UI said the story was over. The machine disagreed.
+
+## Deletion Is Usually Performative
+
+That was the more useful lesson.
+
+Software loves giving you a deletion gesture. A button. A prune command. A little sense of closure.
+
+The closure is often fake.
+
+I found more than seventy orphaned named Docker volumes on each of two servers. Game data, old build caches, multiple generations of Langfuse state, random leftovers from stacks I had already mentally written off. I ran `docker volume prune` first and got almost nothing back. A few anonymous scraps. Sixty-nine kilobytes. Basically a joke.
+
+The real cleanup only happened when I used [`docker volume prune -a`](https://docs.docker.com/reference/cli/docker/volume/prune/ "reference | Docker's full volume-prune mode, required for named orphaned volumes") because modern Docker defaults to sparing named volumes unless you explicitly tell it not to.
+
+That one flag changed the result from "looks clean" to **91 GB reclaimed** across two VPSes.
+
+That gap is what bothers me.
+
+Manual work is fine. The insulting part is the mismatch between the story the tool tells and the story the machine is still living with. A command called `prune` that leaves most of the corpse behind is not cleanup. It is theater.
+
+## There Are Two Kinds of Digital Garbage
+
+I've now gone through both.
+
+The first kind is the garbage you own.
+
+That is the PufferPanel case. I installed something outside my main orchestration path. I removed it only halfway. I let the abstraction boundary hide the remaining work from me. That one is on me. Painful, but fair.
+
+The second kind is the garbage you inherit.
+
+That is the Apple simulator-runtime mess. Here the problem is not laziness. The problem is loss of agency. The platform moves assets into a system-managed place, stops surfacing them cleanly in the normal management flow, and leaves the user holding the bill anyway. You still pay in disk. You just lose the right to finish the deletion.
+
+I can live with paying for my own leftovers. What drives me insane is paying for leftovers the system will not let me remove.
+
+That difference matters. If I flatten both cases into generic "storage bloat," the post becomes boring and dishonest. What actually happened to me was sharper than that.
+
+I made one mess.
+
+I inherited the other.
+
+And both of them taught me that software has a weird moral structure around cleanup. Creation is treated as product. Deletion is treated as janitorial work. So nobody designs endings with the same care they design beginnings.
+
+## Software Rarely Has a Death Model
+
+Most systems have an install path. A setup path. A happy path.
+
+Far fewer have a real death path.
+
+What is the supported end-of-life story for a service that was created outside the current control plane? What is the supported end-of-life story for a simulator runtime the platform no longer wants to acknowledge? What is the supported end-of-life story for all the little persistent artifacts that survive each redeploy, migration, failed experiment, and "I'll clean it later" week?
+
+Usually the answer is: there isn't one.
+
+There is only garbage collection by human shame. You notice a graph looks wrong. You open `du`. You inspect `systemctl`. You stare at a server that feels heavier than it should. Then you start digging through the sediment layers of your own past decisions and the platform's forgotten ones.
+
+That is not a cleanup workflow. That is archaeology.
+
+## The Bill Arrives Quietly
+
+This is why digital waste is so easy to ignore.
+
+Physical junk humiliates you immediately. A broken chair blocks the hallway. Old boxes eat a room. Rot smells.
+
+Software junk is polite. It waits.
+
+It turns into background RAM pressure. Slightly worse disk alerts. Slower backups. Higher cloud bills. A machine that feels "kind of off" for weeks. The bill arrives as friction, not drama.
+
+That subtlety is what makes it dangerous. A lot of digital garbage survives not because it is important, but because it is quiet.
+
+## I Trust Systems More When They Admit What They Keep
+
+I don't expect perfect automation here.
+
+I do not need every platform to magically understand every artifact it ever created. I do want honesty. If removing something only removes the visible layer, say that. If a prune command skips named resources by default, make that painfully obvious. If a runtime asset is parked in protected storage and ordinary tools cannot reclaim the bytes, do not pretend the delete flow is complete.
+
+Good systems help you end things cleanly.
+
+Right now a lot of modern tooling still behaves like endings are somebody else's job.
+
+I know that because I have now been that somebody else twice.
+
+Once because I deserved it.
+
+Once because I didn't.

--- a/content/vi/blogs/260326-the-tax-of-software-that-wont-die.mdx
+++ b/content/vi/blogs/260326-the-tax-of-software-that-wont-die.mdx
@@ -1,0 +1,129 @@
+export const metadata = {
+  title: "Cái thuế của thứ phần mềm mãi không chịu chết",
+  publishDate: "2026-03-26",
+  description: "Một service PufferPanel sống dai, 91 GB Docker volume mồ côi, rồi tới simulator runtime của Apple, tất cả dạy mình cùng một bài học: phần mềm vẫn tiếp tục thu tiền thuê rất lâu sau khi product bảo là nó hết rồi.",
+  category: "Technology",
+  cover_image: "https://images.unsplash.com/photo-1516321318423-f06f85e504b3",
+  tldr: "Mình đã gặp cả hai kiểu rác số: phần còn sót lại do chính mình bày ra, và phần còn sót lại mà platform không cho mình dọn. Điểm chung là phần mềm hiện đại làm chuyện tạo mới rất dễ, nhưng tới lúc một thứ phải chết thì nó vẫn tiếp tục thu thuế.",
+  tags: ["infrastructure", "docker", "apple"],
+};
+
+*Photo by <a href="https://unsplash.com/@carlheyerdahl?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Carl Heyerdahl</a> on <a href="https://unsplash.com/photos/black-flat-screen-computer-monitor-KE0nC8-58MQ?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>*
+
+Tháng trước mình dính hai kiểu thuế phần mềm khác nhau.
+
+Kiểu đầu tiên là do mình.
+
+Mình gỡ [PufferPanel](https://www.pufferpanel.com/ "mention | Panel quản lý game server mà trước đó mình cài bên ngoài Dokploy") khỏi [Dokploy](https://dokploy.com/ "mention | Lớp deploy self-hosted của mình, chỉ quản lý thứ do chính nó tạo") rồi coi như xong. Hoặc ít nhất lúc đó mình tưởng vậy. Vài tuần sau, mình chui vào một con VPS có mức dùng RAM nhìn rất khả nghi, rồi thấy `pufferpanel.service` vẫn còn sống ở tầng host, âm thầm chạy Minecraft server với heap `-Xmx8192M`. Một service bị quên. Tám gig RAM bị giữ sẵn. Cứ nằm đó như tiền nhà mình quên mất là tháng nào cũng phải trả.
+
+Kiểu thứ hai thì không phải lỗi của mình.
+
+Trên macOS, mình đụng phải đống bòng bong quanh iOS simulator runtime. Riêng đống file đã đủ nhức đầu. Còn cách tính dung lượng thì còn oái oăm hơn. Storage settings báo rằng mục Documents đang ngốn **200+ GB**. Mình bấm vào, nghĩ chắc sẽ thấy nguyên bãi tha ma file. UI hiện ra đúng năm file, cộng lại chắc cỡ **1.5 GB**. Tới đoạn đó thì câu hỏi tử tế duy nhất còn lại là: rốt cuộc Apple đang đếm cái gì vậy?
+
+Chính đoạn đó mới làm mình bực.
+
+Xóa file thì phiền. Ừ, chịu được. Nhưng bảo với mình là có hàng trăm GB nằm trong "Documents" trong khi danh sách file nhìn thấy còn chưa đủ thành sai số làm tròn, cái đó mới bực. [Xcode](https://developer.apple.com/xcode/ "reference | IDE chính thức của Apple, cũng là nơi simulator runtime đáng lẽ phải được quản lý") cho bạn một luồng quản lý component nhìn rất gọn gàng. `xcrun simctl` cũng có vài lệnh cleanup. Rồi bạn bắt đầu lục forum, từ [thread này của Apple](https://developer.apple.com/forums/thread/812992 "reference | Báo cáo về simulator runtime mồ côi vẫn nằm trên ổ đĩa trong vùng lưu trữ bị SIP bảo vệ"), qua folklore trên Stack Overflow, tới mấy bài hướng dẫn dọn máy trôi nổi, tới mức bản thân cái category đó cũng hết còn logic. Có thể bạn đang nhìn stale device. Có thể là runtime cài nửa vời. Có thể là mấy CoreSimulator image đang mount. Cũng có thể là runtime asset đang nằm dưới `/System/Library/AssetsV2`, còn file thật thì bị nhét sau một lớp bảo vệ của hệ thống.
+
+Đến đó thì cảm giác nó không còn là cleanup nữa, mà là trừ tà. Happy path rất đơn giản: mở Xcode settings, gỡ runtime, có khi chạy thêm vài lệnh `simctl` cleanup. Broken path thì ngớ ngẩn hẳn: đóng Xcode, soi từng thư mục CoreSimulator, tự phân biệt xem runtime đó là file hay mounted volume, vật nhau với permission, restart simulator service, reboot máy, có khi phải cài lại, rồi kiểm tra xem dung lượng có thật sự quay về không. Tới lúc hiểu mình vừa đi qua cái gì thì bản thân việc dọn dẹp gần như không còn là vấn đề chính nữa.
+
+Hai vụ này khác nhau thật.
+
+Một vụ là mình tự ngu mà ra. Vụ kia thì mình lãnh đủ từ platform.
+
+Nhưng chửi tới đâu thì mình vẫn đụng đúng một chuyện: phần mềm bây giờ sinh ra thứ mới quá dễ, còn dẹp cho nó chết hẳn thì làm như không ai muốn nghĩ tới. Ở thời AI, chuyện đó không còn là một ý niệm lửng lơ nữa. Nó hiện thẳng ra ở tiền RAM, tiền ổ đĩa, tiền máy móc mình phải gánh.
+
+## Phần dễ nhất là tạo ra thứ mới
+
+Chưa bao giờ chuyện spin up phần mềm lại dễ như bây giờ.
+
+Một cú click trong control panel. Một lệnh `docker compose up`. Một lần cài dependency. Một lần tải simulator runtime. Một thử nghiệm mà mình thề là chỉ tạm thời thôi.
+
+Lúc đó chi phí trông rất nhỏ vì cả hệ thống giúp mình dàn nó ra. Storage từng có cảm giác là rẻ. RAM từng có cảm giác là thứ trừu tượng. Giờ thì đằng nào cũng phải trả, chỉ là hóa đơn tới muộn thôi, nhất là khi nửa cái ngành này đang bận biến phần cứng nhàn rỗi thành AI throughput. Background service biến mất sau dashboard. Container làm mọi thứ trông như đồ dùng một lần, cho tới khi bạn nhận ra thứ dùng một lần chỉ là cái interface.
+
+Thứ thật sự được tạo ra ở bên dưới thì chẳng dùng một lần chút nào. Nó là state. Là volume. Là cache. Là service. Là asset. Là mấy thư mục có cái tên mình chưa từng gõ và nằm ở mấy chỗ mình chẳng bao giờ mò tới.
+
+Đó là lúc cú ngu của mình với PufferPanel thú vị hơn chuyện "haha mình quên uninstall một thứ".
+
+Mình có xóa nó ở tầng product. Mình có xóa nó khỏi chỗ mà bình thường mình *nhìn thấy* service của mình. Chừng đó đủ để não mình đánh dấu là xong việc. Nhưng host thì đâu quan tâm tới cảm giác của mình. [systemd](https://systemd.io/ "reference | Trình quản lý service trên Linux, sẽ giữ host-level unit sống tới khi mình stop và disable nó hẳn") vẫn làm đúng thứ mình đã bảo nó làm từ mấy tuần trước: giữ service đó sống.
+
+UI bảo câu chuyện đã hết. Máy thì bảo chưa.
+
+## Xóa thường chỉ là xóa cho có
+
+Đó mới là thứ làm mình ngứa nghề hơn.
+
+Phần mềm rất thích cho mình cái cảm giác là mọi thứ đã xong. Một cái nút xóa. Một lệnh prune. Một màn hình nhìn có vẻ sạch sẽ.
+
+Nhưng nhiều khi chỉ là nhìn vậy thôi.
+
+Mình tìm thấy hơn bảy mươi Docker named volume mồ côi trên mỗi con trong hai con server. Dữ liệu game, build cache cũ, nhiều đời state của Langfuse, rồi đủ thứ tàn dư từ những stack mà trong đầu mình đã cho vào nhóm "xong từ lâu rồi". Ban đầu mình chạy `docker volume prune` và gần như chẳng lấy lại được gì. Vài mẩu anonymous volume. Sáu mươi chín kilobyte. Gần như một trò đùa.
+
+Dọn thật sự chỉ bắt đầu khi mình dùng [`docker volume prune -a`](https://docs.docker.com/reference/cli/docker/volume/prune/ "reference | Chế độ volume-prune đầy đủ của Docker, cần thiết nếu muốn xóa named volume mồ côi") vì Docker bây giờ mặc định vẫn tha cho named volume, trừ khi mình nói toẹt ra là đừng tha nữa.
+
+Chỉ một flag đó thôi đã biến kết quả từ kiểu "nhìn như sạch rồi đó" thành **91 GB lấy lại được** trên hai VPS.
+
+Chính cái độ vênh đó mới làm mình khó chịu.
+
+Tự tay đi dọn thì mình chịu được. Cái bực là tool làm như đã dọn xong, còn cái máy thì vẫn phải ôm nguyên đống xác ở phía sau. Một lệnh tên là `prune` mà để lại gần hết đống rác thì không phải dọn dẹp. Nó chỉ tạo cảm giác là đã dọn thôi.
+
+## Có hai kiểu rác số
+
+Giờ thì mình đã đi qua cả hai.
+
+Kiểu đầu là thứ rác do mình tự tạo.
+
+Đó là vụ PufferPanel. Mình cài một thứ nằm ngoài lớp quản lý chính của mình. Mình chỉ gỡ nó được nửa chừng. Rồi mình để cái ranh giới đó che mất phần việc còn lại khỏi mắt mình. Vụ này là lỗi của mình. Đau thật. Nhưng công bằng.
+
+Kiểu thứ hai là thứ rác mình bị ép phải gánh.
+
+Đó là đống simulator runtime của Apple. Ở đây vấn đề không phải là lười. Vấn đề là mình mất quyền chủ động. Hệ thống đẩy mấy thứ đó vào chỗ nó tự quản, không chỉ ra rõ ràng nữa, nhưng tiền dung lượng thì mình vẫn phải gánh. Mình vẫn phải trả bằng ổ đĩa. Chỉ là mình không còn quyền tự tay dọn cho xong nữa.
+
+Mình chịu được chuyện phải trả tiền cho phần còn sót lại do chính mình gây ra. Thứ làm mình điên hơn là phải trả cho phần còn sót lại mà hệ thống không cho mình xóa.
+
+Sự khác biệt đó quan trọng. Nếu gom cả hai lại thành kiểu "ổ đĩa phình lên" chung chung thì câu chuyện này vừa nhạt vừa sai. Thứ xảy ra với mình khó chịu hơn nhiều.
+
+Một đống rác là mình tự bày ra.
+
+Đống còn lại là mình bị thừa kế.
+
+Và cả hai đều chỉ ra một chuyện rất kỳ cục: lúc làm ra thứ mới thì ai cũng chăm chút, còn tới lúc phải dọn nó đi thì thành việc hậu đậu giao cho người dùng tự chịu. Thế nên phần mở đầu lúc nào cũng được vuốt ve kỹ, còn đoạn kết thì bị bỏ mặc.
+
+## Phần mềm hiếm khi có đường lui tử tế
+
+Đa số hệ thống đều có đường cài vào. Có đường setup. Có đường chạy êm ru.
+
+Nhưng tới lúc muốn dẹp nó đi cho sạch thì sao?
+
+Một service được tạo bên ngoài chỗ mình đang quản thì lúc bỏ nó đi, ai chỉ mình phải dọn những gì? Một simulator runtime mà chính platform cũng làm như không muốn nhắc tới nữa thì rốt cuộc phải gỡ theo đường nào? Còn mấy thứ bám lại sau mỗi lần redeploy, migrate, thử linh tinh rồi quên, thì cuối cùng ai là người phải lôi ra dọn?
+
+Thường là không có câu trả lời tử tế nào cả.
+
+Chỉ có lúc mình thấy hệ thống nặng bất thường, mở graph ra thấy sai sai, rồi bắt đầu mò `du`, soi `systemctl`, đào lại từng lớp quyết định cũ của chính mình với của platform. Lúc đó mình đâu còn "cleanup" gì nữa. Mình đang bới rác cũ lên để lần xem rốt cuộc thứ gì chưa chịu chết.
+
+## Hóa đơn tới rất lặng lẽ
+
+Đó là lý do rác số dễ bị lờ đi đến vậy.
+
+Đồ đạc ngoài đời làm mình bẽ mặt ngay. Một cái ghế gãy chặn giữa lối đi. Vài thùng carton cũ nuốt mất cả góc phòng. Đồ thối thì có mùi.
+
+Rác phần mềm thì lịch sự hơn. Nó ngồi chờ.
+
+Nó biến thành RAM pressure ở nền. Vài cảnh báo ổ đĩa tệ hơn một chút. Backup chậm hơn. Cloud bill cao hơn. Một cái máy có cảm giác "hơi sai sai" suốt mấy tuần. Hóa đơn của nó tới dưới dạng ma sát, không phải drama.
+
+Chính cái kiểu âm thầm đó mới làm nó nguy hiểm. Nhiều loại rác số sống dai không phải vì nó quan trọng, mà vì nó quá im.
+
+## Mình tin hệ thống hơn khi nó nói thật nó giữ lại gì
+
+Mình không đòi tự động hóa phải hoàn hảo.
+
+Mình cũng không đòi platform nào phải hiểu hết mọi thứ nó từng sinh ra. Nhưng ít nhất hãy nói thật. Nếu bấm xóa mà mới chỉ xóa lớp nhìn thấy được, nói thẳng ra. Nếu lệnh prune mặc định bỏ qua named resource, nói cho người ta biết ngay từ đầu. Nếu runtime nằm trong vùng được bảo vệ và công cụ bình thường không lấy lại được chỗ dung lượng đó, thì đừng làm như mọi thứ đã xong rồi.
+
+Một hệ thống tử tế sẽ giúp người dùng dọn cho sạch.
+
+Còn nhiều tool bây giờ vẫn cư xử như thể đoạn dọn rác là việc của ai khác.
+
+Mình biết chuyện đó vì mình vừa phải làm cái phần "ai khác" ấy tới hai lần.
+
+Một lần vì mình đáng bị vậy.
+
+Một lần thì không.


### PR DESCRIPTION
## Summary
- add the new English and Vietnamese software tax posts from the local main history
- refactor reaction overflow rendering into a shared compact panel for blog list and post detail views
- replace the old non-interactive tooltip overflow with a site-matching popover that supports richer reaction chips